### PR TITLE
Add options to guzzle client

### DIFF
--- a/src/WebSmsClient.php
+++ b/src/WebSmsClient.php
@@ -43,7 +43,7 @@ class WebSmsClient
     /**
      * @var Client
      */
-    protected $guzzle;
+    private $guzzle;
 
     /**
      * The endpoint to make the api calls to
@@ -165,7 +165,7 @@ class WebSmsClient
         $this->createGuzzleClient();
     }
 
-    protected function createGuzzleClient()
+    private function createGuzzleClient()
     {
         $this->guzzle = new Client($this->guzzleOptions + [
             'base_uri' => $this->endpoint,

--- a/src/WebSmsClient.php
+++ b/src/WebSmsClient.php
@@ -43,7 +43,7 @@ class WebSmsClient
     /**
      * @var Client
      */
-    private $guzzle;
+    protected $guzzle;
 
     /**
      * The endpoint to make the api calls to
@@ -72,6 +72,13 @@ class WebSmsClient
      * @var string|null
      */
     protected $accessToken = null;
+    
+    /**
+     * The access token used to authenticate against the api
+     *
+     * @var array
+     */
+    protected $guzzleOptions = [];
 
     /**
      * Build the content for the authorization header
@@ -119,6 +126,18 @@ class WebSmsClient
     }
 
     /**
+     * Set additional guzzle options
+     *
+     * @param $options array
+     *
+     * @return void
+     */
+    public function setGuzzleOptions($options)
+    {
+        $this->guzzleOptions = $options;
+    }
+
+    /**
      * Set the access token for authentication
      *
      * @param $accessToken string
@@ -146,9 +165,9 @@ class WebSmsClient
         $this->createGuzzleClient();
     }
 
-    private function createGuzzleClient()
+    protected function createGuzzleClient()
     {
-        $this->guzzle = new Client([
+        $this->guzzle = new Client($this->guzzleOptions + [
             'base_uri' => $this->endpoint,
             'headers' => [
                 'Authorization' =>  $this->getAuthorizationHeader(),


### PR DESCRIPTION
Add guzzleOptions variable and setGuzzleOptions method, also merge guzzleOptions into client creation. This allows e.g. setting proxy options for the guzzle client.