### PR TITLE
Add compatibility for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.6",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/support": "^5.2",
+        "illuminate/support": "^5.2|^6.0",
         "guzzlehttp/guzzle": "~6.0"
     },
     "autoload": {


### PR DESCRIPTION
- Allow higher version for illuminate/support repo

By adding version 6.0 and higher for illuminate/support, we can use this package in Laravel 6.